### PR TITLE
task 1

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.address=0.0.0.0
-server.port=8089
+server.port=8081
 server.http2.enabled=true
 spring.main.allow-bean-definition-overriding=true
 
@@ -26,5 +26,6 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-12,acc-20}
+#payment.accounts=${PAYMENT_ACCOUNTS:acc-12,acc-20}
+payment.accounts=acc-3
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
- смотрим на график, который показывает сколько внешняя система оплаты получает от нас запросов и какие у них исходы
<img width="1808" height="550" alt="image" src="https://github.com/user-attachments/assets/bc921a3b-f2d7-4bec-bc3b-1bb0b408cae1" />

- видим, что не вписываемся в лимит провайдера для аккаунта

- rps для acc-3 равен 10, а в нашем кейсе rps 11

- добавляем SlidingWindowRateLimiter, чтобы вписаться в ограничения 

- радуемся:
<img width="1143" height="409" alt="image" src="https://github.com/user-attachments/assets/eef55712-9653-4f6d-b637-0818a7329aae" />
<img width="1154" height="469" alt="image" src="https://github.com/user-attachments/assets/7fa282b9-bd8f-464a-b225-e9dd6d77c149" />
<img width="1145" height="489" alt="Снимок экрана 2025-09-18 222010" src="https://github.com/user-attachments/assets/1412bbe1-3a6a-4cad-a2aa-68d37adab465" />

