### PR TITLE
Task 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-alpine-3.22
 
 COPY --from=build /app/target/*.jar /high-load-course.jar
 
 CMD ["java", "-jar", "/high-load-course.jar"]
-

--- a/src/main/kotlin/ru/quipy/PaymentMetrics.kt
+++ b/src/main/kotlin/ru/quipy/PaymentMetrics.kt
@@ -12,6 +12,51 @@ class PaymentMetrics {
         .tag("type", "payment")
         .register(Metrics.globalRegistry)
 
+    val processPaymentStartedCounter = Counter.builder("process_payment_started_total")
+        .description("Number of process payment started")
+        .tag("type", "payment")
+        .register(Metrics.globalRegistry)
+
+    val processPaymentRateLimiterPassedCounter = Counter.builder("process_payment_rate_limiter_passed")
+        .description("processPaymentRateLimiterPassedCounter")
+        .tag("type", "payment")
+        .register(Metrics.globalRegistry)
+
+    val performPaymentStartedCounter = Counter.builder("perform_payment_started_total")
+        .description("performPaymentStartedCounter")
+        .tag("type", "payment")
+        .register(Metrics.globalRegistry)
+
+    val submissionLogged = Counter.builder("submission_logged")
+        .description("submissionLogged")
+        .tag("type", "payment")
+        .register(Metrics.globalRegistry)
+
+    val windowAcquired = Counter.builder("window_acquired")
+        .description("windowAcquired")
+        .tag("type", "payment")
+        .register(Metrics.globalRegistry)
+
+    val rateLimiterAcquired = Counter.builder("rate_limiter_acquired")
+        .description("rateLimiterAcquired")
+        .tag("type", "payment")
+        .register(Metrics.globalRegistry)
+
+    val responseReceived = Counter.builder("response_received")
+            .description("responseReceived")
+            .tag("type", "payment")
+            .register(Metrics.globalRegistry)
+
+    val bodyRead = Counter.builder("body_read")
+        .description("bodyRead")
+        .tag("type", "payment")
+        .register(Metrics.globalRegistry)
+
+    val processingLogged = Counter.builder("processing_logged")
+        .description("processingLogged")
+        .tag("type", "payment")
+        .register(Metrics.globalRegistry)
+
     val paymentOperationDurationTimer = Timer.builder("payment_operation_duration_seconds")
         .description("Payment processing duration in seconds")
         .tag("type", "payment")

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -53,19 +53,19 @@ class OrderPayer {
         val slaSeconds = 1.0
         val processingTimeSeconds = 0.01
 
-        val safeQueueTimeSeconds = (slaSeconds - processingTimeSeconds) * 0.5
-        val bucketSize = (externalServiceRps * safeQueueTimeSeconds).toInt()
+        val safeQueueTimeSeconds = (slaSeconds - processingTimeSeconds) * 0.8
+        // val bucketSize = (externalServiceRps * safeQueueTimeSeconds).toInt()
 
         rateLimiter = TokenBucketRateLimiter(
             rate = externalServiceRps,
             window = 1,
-            bucketMaxCapacity = bucketSize,
+            bucketMaxCapacity = externalServiceRps,
             timeUnit = TimeUnit.SECONDS
         )
 
         paymentExecutor = ThreadPoolExecutor(
-            40,
-            40,
+            50,
+            50,
             0L,
             TimeUnit.MILLISECONDS,
             LinkedBlockingQueue(30000),
@@ -107,7 +107,7 @@ class OrderPayer {
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         if (!rateLimiter.tick()) {
             logger.warn("429 TooMany Req. OrderId: ${orderId}, PaymentId: ${paymentId}")
-            throw TooManyRequestsWithRetryAfterException(20)
+            throw TooManyRequestsWithRetryAfterException(retryAfter)
         }
 
         val createdAt = System.currentTimeMillis()

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -53,7 +53,7 @@ class OrderPayer {
         val slaSeconds = 1.0
         val processingTimeSeconds = 0.01
 
-        val safeQueueTimeSeconds = (slaSeconds - processingTimeSeconds) * 0.8
+        val safeQueueTimeSeconds = (slaSeconds - processingTimeSeconds) * 0.5
         val bucketSize = (externalServiceRps * safeQueueTimeSeconds).toInt()
 
         rateLimiter = TokenBucketRateLimiter(

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -64,8 +64,8 @@ class OrderPayer {
         )
 
         paymentExecutor = ThreadPoolExecutor(
-            100,
-            100,
+            40,
+            40,
             0L,
             TimeUnit.MILLISECONDS,
             LinkedBlockingQueue(30000),
@@ -105,10 +105,10 @@ class OrderPayer {
     }
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
-//        if (!rateLimiter.tick()) {
-//            logger.warn("429 TooMany Req. OrderId: ${orderId}, PaymentId: ${paymentId}")
-//            throw TooManyRequestsWithRetryAfterException(20)
-//        }
+        if (!rateLimiter.tick()) {
+            logger.warn("429 TooMany Req. OrderId: ${orderId}, PaymentId: ${paymentId}")
+            throw TooManyRequestsWithRetryAfterException(20)
+        }
 
         val createdAt = System.currentTimeMillis()
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -74,6 +74,7 @@ class OrderPayer {
             NamedThreadFactory("payment-submission-executor"),
             CallerBlockingRejectedExecutionHandler()
         )
+        paymentExecutor.prestartAllCoreThreads()
 
         executorScope = CoroutineScope(paymentExecutor.asCoroutineDispatcher())
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -50,8 +50,8 @@ class OrderPayer {
     @PostConstruct
     fun init() {
         val accountProperties = paymentService.getAllAccountsProperties()
-        retryAfter = accountProperties.minOf { it.averageProcessingTime }.toMillis() * 3
-        val externalServiceRps = accountProperties.minOf { it.rateLimitPerSec }
+        retryAfter = accountProperties.minOf { it.averageProcessingTime }.toMillis() * 5
+        val externalServiceRps = 800
         val slaSeconds = 1.0
         val processingTimeSeconds = 0.01
 
@@ -66,8 +66,8 @@ class OrderPayer {
         )
 
         paymentExecutor = ThreadPoolExecutor(
-            50,
-            50,
+            150,
+            150,
             0L,
             TimeUnit.MILLISECONDS,
             LinkedBlockingQueue(30000),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -49,9 +49,9 @@ class OrderPayer {
     fun init() {
         val accountProperties = paymentService.getAllAccountsProperties()
         retryAfter = accountProperties.minOf { it.averageProcessingTime }.toMillis()
-        val externalServiceRps = accountProperties.minOf { it.rateLimitPerSec }
-        val slaSeconds = 50.0
-        val processingTimeSeconds = 10.0
+        val externalServiceRps = 2000
+        val slaSeconds = 1.0
+        val processingTimeSeconds = 0.01
 
         val safeQueueTimeSeconds = (slaSeconds - processingTimeSeconds) * 0.8
         val bucketSize = (externalServiceRps * safeQueueTimeSeconds).toInt()
@@ -64,8 +64,8 @@ class OrderPayer {
         )
 
         paymentExecutor = ThreadPoolExecutor(
-            500,
-            500,
+            100,
+            100,
             0L,
             TimeUnit.MILLISECONDS,
             LinkedBlockingQueue(30000),
@@ -107,7 +107,7 @@ class OrderPayer {
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         if (!rateLimiter.tick()) {
             logger.warn("429 TooMany Req. OrderId: ${orderId}, PaymentId: ${paymentId}")
-            throw TooManyRequestsWithRetryAfterException(retryAfter)
+            throw TooManyRequestsWithRetryAfterException(20)
         }
 
         val createdAt = System.currentTimeMillis()

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -107,10 +107,12 @@ class OrderPayer {
     }
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
+        paymentMetrics.processPaymentStartedCounter.increment()
         if (!rateLimiter.tick()) {
             logger.warn("429 TooMany Req. OrderId: ${orderId}, PaymentId: ${paymentId}")
             throw TooManyRequestsWithRetryAfterException(retryAfter)
         }
+        paymentMetrics.processPaymentRateLimiterPassedCounter.increment()
 
         val createdAt = System.currentTimeMillis()
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -49,7 +49,7 @@ class OrderPayer {
     fun init() {
         val accountProperties = paymentService.getAllAccountsProperties()
         retryAfter = accountProperties.minOf { it.averageProcessingTime }.toMillis()
-        val externalServiceRps = 2000
+        val externalServiceRps = accountProperties.minOf { it.rateLimitPerSec }
         val slaSeconds = 1.0
         val processingTimeSeconds = 0.01
 
@@ -105,10 +105,10 @@ class OrderPayer {
     }
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
-        if (!rateLimiter.tick()) {
-            logger.warn("429 TooMany Req. OrderId: ${orderId}, PaymentId: ${paymentId}")
-            throw TooManyRequestsWithRetryAfterException(20)
-        }
+//        if (!rateLimiter.tick()) {
+//            logger.warn("429 TooMany Req. OrderId: ${orderId}, PaymentId: ${paymentId}")
+//            throw TooManyRequestsWithRetryAfterException(20)
+//        }
 
         val createdAt = System.currentTimeMillis()
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -4,8 +4,10 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.Metrics
 import jakarta.annotation.PostConstruct
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,8 +44,8 @@ class OrderPayer {
     private lateinit var rateLimiter: RateLimiter
     private var retryAfter: Long = 0
 
-    private lateinit var paymentExecutor: ThreadPoolExecutor;
-    private lateinit var executorScope: CoroutineScope;
+    private lateinit var paymentExecutor: ThreadPoolExecutor
+    private lateinit var executorScope: CoroutineScope
 
     @PostConstruct
     fun init() {
@@ -73,7 +75,7 @@ class OrderPayer {
             CallerBlockingRejectedExecutionHandler()
         )
 
-        executorScope = CoroutineScope(paymentExecutor.asCoroutineDispatcher());
+        executorScope = CoroutineScope(paymentExecutor.asCoroutineDispatcher())
 
         setupMetrics()
     }
@@ -113,18 +115,17 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         executorScope.launch {
-            val createdEvent = paymentESService.create {
-                it.create(
-                    paymentId,
-                    orderId,
-                    amount
-                )
+            val createdEvent = withContext(Dispatchers.IO) {
+                paymentESService.create {
+                    it.create(paymentId, orderId, amount)
+                }
             }
+
             logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
             paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
-            val duration = System.currentTimeMillis() - createdAt;
-            paymentMetrics.paymentTotalDurationTimer.record(duration, TimeUnit.MILLISECONDS);
+            val duration = System.currentTimeMillis() - createdAt
+            paymentMetrics.paymentTotalDurationTimer.record(duration, TimeUnit.MILLISECONDS)
         }
         return createdAt
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -48,18 +48,18 @@ class OrderPayer {
     @PostConstruct
     fun init() {
         val accountProperties = paymentService.getAllAccountsProperties()
-        retryAfter = accountProperties.minOf { it.averageProcessingTime }.toMillis()
+        retryAfter = accountProperties.minOf { it.averageProcessingTime }.toMillis() * 3
         val externalServiceRps = accountProperties.minOf { it.rateLimitPerSec }
         val slaSeconds = 1.0
         val processingTimeSeconds = 0.01
 
-        val safeQueueTimeSeconds = (slaSeconds - processingTimeSeconds) * 0.8
-        // val bucketSize = (externalServiceRps * safeQueueTimeSeconds).toInt()
+        val safeQueueTimeSeconds = (slaSeconds - processingTimeSeconds) * 0.7
+        val bucketSize = (externalServiceRps * safeQueueTimeSeconds).toInt()
 
         rateLimiter = TokenBucketRateLimiter(
             rate = externalServiceRps,
             window = 1,
-            bucketMaxCapacity = externalServiceRps,
+            bucketMaxCapacity = bucketSize,
             timeUnit = TimeUnit.SECONDS
         )
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -105,10 +105,10 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
         repeat(maxRetries) { attempt ->
-            // if (System.currentTimeMillis() - startTime >= paymentTimeout) {
-            //    logger.warn("[$accountName] Deadline approaching, stopping retries for $paymentId")
-            //    return
-            // }
+             if (System.currentTimeMillis() - startTime >= paymentTimeout) {
+                logger.warn("[$accountName] Deadline approaching, stopping retries for $paymentId")
+                return
+             }
 
             try {
                 ongoingWindow.acquireAsync();

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -88,6 +88,7 @@ class PaymentExternalSystemAdapterImpl(
     }
 
     override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        paymentMetrics.performPaymentStartedCounter.increment()
         val startTime = System.currentTimeMillis();
         logger.warn("[$accountName] Submitting payment request for payment $paymentId, avgProcessingTime: $requestAverageProcessingTime")
 
@@ -98,6 +99,7 @@ class PaymentExternalSystemAdapterImpl(
         paymentESService.update(paymentId) {
             it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
+        paymentMetrics.submissionLogged.increment()
 
         val paymentTimeout = 1000L
 
@@ -109,8 +111,10 @@ class PaymentExternalSystemAdapterImpl(
              }
 
             try {
-                ongoingWindow.acquireAsync();
+                ongoingWindow.acquireAsync()
+                paymentMetrics.windowAcquired.increment()
                 acquireRateLimitPermission()
+                paymentMetrics.rateLimiterAcquired.increment()
                 val request = HttpRequest.newBuilder()
                     .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))
                     .POST(HttpRequest.BodyPublishers.noBody())
@@ -118,6 +122,7 @@ class PaymentExternalSystemAdapterImpl(
                     .build()
 
                 val response = client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).await()
+                paymentMetrics.responseReceived.increment()
 
                 val body = try {
                     mapper.readValue(response.body(), ExternalSysResponse::class.java)
@@ -125,6 +130,7 @@ class PaymentExternalSystemAdapterImpl(
                     logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
                     ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
                 }
+                paymentMetrics.bodyRead.increment()
 
                 logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}, code: ${response.statusCode()}, attempt: $attempt")
 
@@ -133,6 +139,7 @@ class PaymentExternalSystemAdapterImpl(
                 paymentESService.update(paymentId) {
                     it.logProcessing(body.result, now(), transactionId, reason = body.message)
                 }
+                paymentMetrics.processingLogged.increment()
 
                 if (body.result) {
                     recordPaymentAttempt(attempt)
@@ -143,6 +150,7 @@ class PaymentExternalSystemAdapterImpl(
                 paymentESService.update(paymentId) {
                     it.logProcessing(false, now(), transactionId, reason = e.message)
                 }
+                paymentMetrics.processingLogged.increment()
             } finally {
                 ongoingWindow.release()
             }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -81,8 +81,10 @@ class PaymentExternalSystemAdapterImpl(
 
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-        paymentESService.update(paymentId) {
-            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+        withContext(Dispatchers.IO) {
+            paymentESService.update(paymentId) {
+                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            }
         }
 
         val paymentTimeout = 1000L
@@ -116,8 +118,10 @@ class PaymentExternalSystemAdapterImpl(
 
                 // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
                 // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                paymentESService.update(paymentId) {
-                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                withContext(Dispatchers.IO) {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                    }
                 }
 
                 if (body.result) {
@@ -126,8 +130,10 @@ class PaymentExternalSystemAdapterImpl(
                 }
             } catch (e: Exception) {
                 logger.error("[$accountName] Payment failed for $paymentId", e)
-                paymentESService.update(paymentId) {
-                    it.logProcessing(false, now(), transactionId, reason = e.message)
+                withContext(Dispatchers.IO) {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = e.message)
+                    }
                 }
             } finally {
                 ongoingWindow.release()

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,8 +2,6 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import io.github.resilience4j.ratelimiter.RateLimiter
-import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Timer
@@ -56,10 +54,7 @@ class PaymentExternalSystemAdapterImpl(
     private val client = HttpClient.newBuilder()
         .version(HttpClient.Version.HTTP_2)
         .build()
-    private val rateLimiter = RateLimiter.of("rate-limiter", RateLimiterConfig.custom()
-        .limitForPeriod(rateLimitPerSec)
-        .limitRefreshPeriod(Duration.ofMillis(1000))
-        .build())
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1));
     private val ongoingWindow = OngoingWindow(parallelRequests)
 
     fun recordPaymentAttempt(attempts: Int) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -91,10 +91,10 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
         repeat(maxRetries) { attempt ->
-            if (System.currentTimeMillis() - startTime >= paymentTimeout) {
-                logger.warn("[$accountName] Deadline approaching, stopping retries for $paymentId")
-                return
-            }
+            // if (System.currentTimeMillis() - startTime >= paymentTimeout) {
+            //    logger.warn("[$accountName] Deadline approaching, stopping retries for $paymentId")
+            //    return
+            // }
 
             try {
                 ongoingWindow.acquireAsync();

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,6 +2,8 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Timer
@@ -54,7 +56,19 @@ class PaymentExternalSystemAdapterImpl(
     private val client = HttpClient.newBuilder()
         .version(HttpClient.Version.HTTP_2)
         .build()
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1));
+    private val rateLimiter: RateLimiter = run {
+        val config = RateLimiterConfig.custom()
+            .limitForPeriod(rateLimitPerSec)
+            .limitRefreshPeriod(Duration.ofSeconds(1))
+            .timeoutDuration(Duration.ofSeconds(3600))
+            .build()
+        RateLimiter.of("payment-rate-limiter", config)
+    }
+
+    private suspend fun acquireRateLimitPermission() {
+        val waitTimeNanos = rateLimiter.reservePermission()
+        delay(waitTimeNanos / 1_000_000)
+    }
     private val ongoingWindow = OngoingWindow(parallelRequests)
 
     fun recordPaymentAttempt(attempts: Int) {
@@ -98,7 +112,7 @@ class PaymentExternalSystemAdapterImpl(
 
             try {
                 ongoingWindow.acquireAsync();
-                rateLimiter.tickBlockingAsync();
+                acquireRateLimitPermission()
                 val request = HttpRequest.newBuilder()
                     .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))
                     .POST(HttpRequest.BodyPublishers.noBody())

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,6 +2,8 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Timer
@@ -54,7 +56,10 @@ class PaymentExternalSystemAdapterImpl(
     private val client = HttpClient.newBuilder()
         .version(HttpClient.Version.HTTP_2)
         .build()
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1));
+    private val rateLimiter = RateLimiter.of("rate-limiter", RateLimiterConfig.custom()
+        .limitForPeriod(rateLimitPerSec)
+        .limitRefreshPeriod(Duration.ofMillis(1000))
+        .build())
     private val ongoingWindow = OngoingWindow(parallelRequests)
 
     fun recordPaymentAttempt(attempts: Int) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -95,10 +95,8 @@ class PaymentExternalSystemAdapterImpl(
 
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-        withContext(Dispatchers.IO) {
-            paymentESService.update(paymentId) {
-                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
-            }
+        paymentESService.update(paymentId) {
+            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
 
         val paymentTimeout = 1000L
@@ -132,10 +130,8 @@ class PaymentExternalSystemAdapterImpl(
 
                 // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
                 // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                withContext(Dispatchers.IO) {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                    }
+                paymentESService.update(paymentId) {
+                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
                 }
 
                 if (body.result) {
@@ -144,10 +140,8 @@ class PaymentExternalSystemAdapterImpl(
                 }
             } catch (e: Exception) {
                 logger.error("[$accountName] Payment failed for $paymentId", e)
-                withContext(Dispatchers.IO) {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = e.message)
-                    }
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = e.message)
                 }
             } finally {
                 ongoingWindow.release()

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -49,10 +49,9 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val maxRetries = 4
+    private val maxRetries = 10
 
     private val client = HttpClient.newBuilder()
-        .executor(Executors.newFixedThreadPool(100))
         .version(HttpClient.Version.HTTP_2)
         .build()
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1));
@@ -86,7 +85,7 @@ class PaymentExternalSystemAdapterImpl(
             it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
 
-        val paymentTimeout = 50000L
+        val paymentTimeout = 20L
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
         repeat(maxRetries) { attempt ->
@@ -101,7 +100,7 @@ class PaymentExternalSystemAdapterImpl(
                 val request = HttpRequest.newBuilder()
                     .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))
                     .POST(HttpRequest.BodyPublishers.noBody())
-                    .timeout(Duration.ofSeconds(paymentTimeout))
+                    .timeout(Duration.ofMillis(paymentTimeout))
                     .build()
 
                 val response = client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).await()

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -85,7 +85,7 @@ class PaymentExternalSystemAdapterImpl(
             it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
 
-        val paymentTimeout = 20L
+        val paymentTimeout = 1000L
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
         repeat(maxRetries) { attempt ->

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -105,10 +105,6 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
         repeat(maxRetries) { attempt ->
-             if (System.currentTimeMillis() - startTime >= paymentTimeout) {
-                logger.warn("[$accountName] Deadline approaching, stopping retries for $paymentId")
-                return
-             }
 
             try {
                 ongoingWindow.acquireAsync()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,5 +29,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=acc-12
+payment.accounts=acc-13
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}

--- a/test-local-run.http
+++ b/test-local-run.http
@@ -5,9 +5,9 @@ Content-Type: application/json
 {
   "serviceName": "{{serviceName}}",
   "token": "{{token}}",
-  "ratePerSecond": 1000,
-  "testCount": 200000,
-  "processingTimeMillis": 50000
+  "ratePerSecond": 4000,
+  "testCount": 1500000,
+  "processingTimeMillis": 1000
 }
 
 ### Stop running test to save time and resources


### PR DESCRIPTION
В этом кейсе у нас падали HTTP запросы. Есть предположение, что падали они из-за большого количества корутин, которые просто висели в очереди (на графиках видно, что body возвращают только единицы, остальные запросы, которые успешно отработали, отрабатывают за адекватное время). В итоге пришли к идее, что можно попробовать уменьшить rps у TokenBucket. Эмпирически вычислили, что оптимальное значение 800. Аналогично с retryAfter, чтобы запросы не спамили нам в систему. Получили 50 мс, как оптимальное значение. Но и это не давало стабильного результата. Тогда решили ещё увеличить corePoolSize до 150 и таким образом получилось сгладить некоторые таймауты